### PR TITLE
fix(window-handler): adds polling for window configuration

### DIFF
--- a/public/output-window.html
+++ b/public/output-window.html
@@ -1,4 +1,4 @@
 <!-- prettier-ignore -->
 <html>
-  <body style="margin: 0px; background-color: rgb(0, 0, 0); display: flex; justify-content: center; align-items: center;"></body>
+  <body style="margin: 0px; display: flex; justify-content: center; align-items: center;" />
 </html>


### PR DESCRIPTION
Electron seems to not fire the load events all the time for native window.open()s, so I added in a
polling function to check when the document is ready to be touched