### PR TITLE
fix(lifecycle): fixes lifecycle bug in modV & galleryitem compont

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -143,7 +143,9 @@ export default {
   },
 
   async mounted() {
-    await this.$modV.setup();
+    if (!this.$modV.ready) {
+      await this.$modV.setup();
+    }
     // this.$modV.$worker.addEventListener("message", e => {
     //   if (e.data.type === "outputs/SET_MAIN_OUTPUT") {
     //     this.resize();

--- a/src/application/worker/store/modules/groups.js
+++ b/src/application/worker/store/modules/groups.js
@@ -90,6 +90,15 @@ const sharedPropertyRestrictions = {
 const actions = {
   async createGroup({ commit }, args = {}) {
     const name = args.name || "New Group";
+    const writeTo = args.writeToSwap ? swap : state;
+
+    const existingGroupIndex = writeTo.groups.findIndex(
+      group => group.name === args.name
+    );
+
+    if (existingGroupIndex > -1) {
+      return writeTo.groups[existingGroupIndex];
+    }
 
     const group = {
       ...args,

--- a/src/application/worker/store/modules/modules.js
+++ b/src/application/worker/store/modules/modules.js
@@ -83,7 +83,7 @@ const actions = {
     const { renderers } = rootState;
 
     if (!module) {
-      console.error("No module to register");
+      console.error("No module to register.");
       return;
     }
 
@@ -94,12 +94,21 @@ const actions = {
 
     const { name, type } = module.meta;
 
+    const existingModuleWithDuplicateName = Object.values(
+      state.registered
+    ).findIndex(registeredModule => registeredModule.meta.name === name);
+
+    if (existingModuleWithDuplicateName > -1) {
+      console.error(`Module registered with name "${name}" already exists.`);
+      return;
+    }
+
     if (renderers[type].setupModule) {
       try {
         module = await renderers[type].setupModule(module);
       } catch (e) {
         console.error(
-          `Error in ${type} renderer setup whilst registering ${name}. This module was ommited from registration.`
+          `Error in ${type} renderer setup whilst registering "${name}". This module was ommited from registration.`
         );
 
         return false;
@@ -124,6 +133,22 @@ const actions = {
       meta: { ...moduleDefinition.meta, ...moduleMeta },
       ...existingModule
     };
+
+    if (moduleMeta.isGallery) {
+      const existingModuleWithDuplicateNameInGallery = Object.values(
+        writeTo.active
+      ).find(
+        activeModule =>
+          activeModule.meta.isGallery && activeModule.meta.name === moduleName
+      );
+
+      if (existingModuleWithDuplicateNameInGallery) {
+        console.warn(
+          `Module active in gallery with name "${moduleName}" already exists.`
+        );
+        return existingModuleWithDuplicateNameInGallery;
+      }
+    }
 
     if (!existingModule) {
       module.$id = uuidv4();

--- a/src/components/GalleryItem.vue
+++ b/src/components/GalleryItem.vue
@@ -78,7 +78,9 @@ export default {
   },
 
   beforeDestroy() {
-    this.$modV.store.commit("modules/REMOVE_ACTIVE_MODULE", this.id);
+    this.$modV.store.commit("modules/REMOVE_ACTIVE_MODULE", {
+      moduleId: this.id
+    });
     this.$modV.store.commit("outputs/REMOVE_AUXILLARY", this.outputId);
     this.$modV.store.commit("groups/REMOVE_MODULE_FROM_GROUP", {
       groupId: this.groupId,


### PR DESCRIPTION
Fixes a bad call to remove gallery item modules when their component was destroyed and checks if modV.setup was already called in App.vue

fix #102