### PR TITLE
fix(__dirname): adds horrible wrapper hack for __dirname with webpack…

### DIFF
--- a/src/application/index.js
+++ b/src/application/index.js
@@ -9,7 +9,7 @@ import use from "./use";
 
 import PromiseWorker from "promise-worker-transferable";
 
-import { ipcRenderer } from "electron";
+import { ipcRenderer, remote } from "electron";
 
 let imageBitmap;
 const imageBitmapQueue = [];
@@ -34,6 +34,11 @@ export default class ModV {
   constructor() {
     this.$worker = new Worker();
     this.$asyncWorker = new PromiseWorker(this.$worker);
+
+    this.$worker.postMessage({
+      type: "__dirname",
+      payload: remote.app.getAppPath()
+    });
 
     this.$worker.addEventListener("message", e => {
       if (e.data.type === "tick" && this.ready) {

--- a/src/application/worker/store/modules/ndi.js
+++ b/src/application/worker/store/modules/ndi.js
@@ -1,7 +1,16 @@
-import grandiose from "grandiose";
+/* globals __dirname */
+
 import uuidv4 from "uuid/v4";
 import Vue from "vue";
 import store from "../";
+
+// eslint-disable-next-line
+__dirname = `${__dirname}/node_modules/grandiose`;
+
+const grandiose = require("grandiose");
+
+// eslint-disable-next-line
+__dirname = __dirname.replace("/node_modules/grandiose", "");
 
 const state = {
   discovering: false,


### PR DESCRIPTION
… & electron & workers

This is an abominable hack which works around the fact webpack just does whatever the fuck it wants with workers. We stall everything in the worker until we've sent it the correct path to the .asar, then in the NDI store module we temporarily set the location of grandiose within the .asar.
Guaranteed this will come back to bite us in the arse.

fix #114