### PR TITLE
fix(vue-devtools): removes vue-devtools integration

### DIFF
--- a/src/background.js
+++ b/src/background.js
@@ -8,10 +8,7 @@ import {
   Menu
 } from "electron";
 
-import {
-  createProtocol,
-  installVueDevtools
-} from "vue-cli-plugin-electron-builder/lib";
+import { createProtocol } from "vue-cli-plugin-electron-builder/lib";
 
 import fs from "fs";
 import MediaManager from "./media-manager";
@@ -320,19 +317,6 @@ app.on("ready", async () => {
     "true"
   );
 
-  if (isDevelopment && !process.env.IS_TEST) {
-    // Install Vue Devtools
-    // Devtools extensions are broken in Electron 6.0.0 and greater
-    // See https://github.com/nklayman/vue-cli-plugin-electron-builder/issues/378 for more info
-    // Electron will not launch with Devtools extensions installed on Windows 10 with dark mode
-    // If you are not using Windows 10 dark mode, you may uncomment these lines
-    // In addition, if the linked issue is closed, you can upgrade electron and uncomment these lines
-    try {
-      await installVueDevtools();
-    } catch (e) {
-      console.error("Vue Devtools failed to install:", e.toString());
-    }
-  }
   createWindow();
 });
 


### PR DESCRIPTION
Removes injection of the Vue devtools as they fail to install and break the build on Windows 10

fix #127