### PR TITLE
fix(groups): fixes group re-ordering

### DIFF
--- a/src/application/worker/store/modules/groups.js
+++ b/src/application/worker/store/modules/groups.js
@@ -122,6 +122,14 @@ const actions = {
     return group;
   },
 
+  orderByIds({ commit }, { ids }) {
+    const newGroups = ids.map(id => {
+      return state.groups.find(group => group.id === id);
+    });
+
+    commit("REPLACE_GROUPS", { groups: newGroups });
+  },
+
   createPresetData() {
     return state.groups
       .filter(group => group.name !== constants.GALLERY_GROUP_NAME)

--- a/src/components/Groups.vue
+++ b/src/components/Groups.vue
@@ -66,8 +66,10 @@ export default {
         );
       },
 
-      set(value) {
-        this.$modV.store.commit("groups/REPLACE_GROUPS", value);
+      async set(value) {
+        await this.$modV.store.dispatch("groups/orderByIds", {
+          ids: value.map(group => group.id)
+        });
       }
     },
 


### PR DESCRIPTION
Vuex commit would send the renderer version of the group state to the worker, destroying complex objects such as group.context. Created a new action to send a list of IDs to rearrange group order instead.

fixes #155