### PR TITLE
feat(debugger): adds scaled drawImage to debugger

### DIFF
--- a/src/application/worker/loop.js
+++ b/src/application/worker/loop.js
@@ -290,14 +290,20 @@ function loop(delta, features) {
     const canvasToDebug = store.getters["outputs/canvasToDebug"];
 
     if (canvasToDebug) {
-      debugCanvas.width = canvasToDebug.context.canvas.width;
-      debugCanvas.height = canvasToDebug.context.canvas.height;
+      const { width: dWidth, height: dHeight } = canvasToDebug.context.canvas;
+      const aspectRatio = dWidth / dHeight;
+      debugCanvas.height = debugCanvas.width / aspectRatio;
 
       debugContext.clearRect(0, 0, debugCanvas.width, debugCanvas.height);
-      debugContext.drawImage(canvasToDebug.context.canvas, 0, 0);
+      debugContext.drawImage(
+        canvasToDebug.context.canvas,
+        0,
+        0,
+        debugCanvas.width,
+        debugCanvas.height
+      );
       debugContext.font = "32px monospace";
       debugContext.textBaseline = "hanging";
-      debugContext.save();
       debugContext.fillStyle = "#fff";
       debugContext.globalCompositeOperation = "difference";
       debugContext.fillText(
@@ -305,7 +311,6 @@ function loop(delta, features) {
         10,
         10
       );
-      debugContext.restore();
     }
   }
 

--- a/src/application/worker/store/modules/outputs.js
+++ b/src/application/worker/store/modules/outputs.js
@@ -101,6 +101,10 @@ const actions = {
 
       commit("RESIZE_AUXILLARY", { id: outputContext.id, width, height });
     }
+  },
+
+  resizeDebug({ commit }, { width, height }) {
+    commit("RESIZE_DEBUG", { width, height });
   }
 };
 
@@ -140,6 +144,20 @@ const mutations = {
 
   TOGGLE_DEBUG(state, debug) {
     state.debug = debug;
+  },
+
+  RESIZE_DEBUG(state, { width, height }) {
+    if (!state.debugContext.canvas) {
+      return;
+    }
+
+    if (width) {
+      state.debugContext.canvas.width = width;
+    }
+
+    if (height) {
+      state.debugContext.canvas.height = height;
+    }
   },
 
   SET_DEBUG_ID(state, id) {


### PR DESCRIPTION
Adds a resizeObserver to the debugger and a new Vuex store action and
mutation to allow for more performant drawing to the debugger canvas.